### PR TITLE
feat : 레시피 상세페이지 기능 추가 (2~3)

### DIFF
--- a/src/components/recipedetailpage/GroupedIngredientList.tsx
+++ b/src/components/recipedetailpage/GroupedIngredientList.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+interface RecipeIngredient {
+	name: string;
+	volume: number | string;
+}
+
+interface GroupIngredientList {
+	ingredients: RecipeIngredient[];
+	className?: string;
+}
+
+const GroupedIngredientList: React.FC<GroupIngredientList> = ({
+	ingredients,
+	className,
+}) => {
+	const groupIngredients = (
+		ingredients: RecipeIngredient[]
+	): RecipeIngredient[][] => {
+		const groups: RecipeIngredient[][] = [];
+		for (let i = 0; i < ingredients.length; i += 6) {
+			groups.push(ingredients.slice(i, i + 6));
+		}
+		return groups;
+	};
+
+	const groupedIngredients = groupIngredients(ingredients);
+
+	return (
+		<div className={className}>
+			{groupedIngredients.map((group, groupIndex) => (
+				<ul key={groupIndex}>
+					{group.map((ingredient, index) => (
+						<li key={index}>
+							{ingredient.name} <span>{ingredient.volume}</span>
+						</li>
+					))}
+				</ul>
+			))}
+		</div>
+	);
+};
+
+export default GroupedIngredientList;

--- a/src/pages/recipedetail/RecipeDetail.module.css
+++ b/src/pages/recipedetail/RecipeDetail.module.css
@@ -146,6 +146,11 @@ h4 em::before {
 	position: relative;
 }
 
+/* 1개의 ul일 때 */
+.cookingIngredientList ul:first-child {
+	width: 100%;
+}
+
 /* 2개의 ul일 때 */
 .cookingIngredientList ul:first-child:nth-last-child(2),
 .cookingIngredientList ul:first-child:nth-last-child(2) ~ ul {

--- a/src/pages/recipedetail/RecipeDetail.tsx
+++ b/src/pages/recipedetail/RecipeDetail.tsx
@@ -13,13 +13,14 @@ import { getFirestore, getDoc, doc } from 'firebase/firestore';
 import { getAuth } from 'firebase/auth';
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import GroupedIngredientList from '../../components/recipedetailpage/GroupedIngredientList';
 
 interface RecipeTime {
 	hours: number;
 	minutes: number;
 }
 
-interface RecipeIngredients {
+interface RecipeIngredient {
 	name: string;
 	volume: number | string;
 }
@@ -40,7 +41,7 @@ interface Recipe {
 	recipe_difficulty: string | number;
 	recipe_steps: RecipeSteps;
 	recipe_tips: string;
-	recipe_ingredients: RecipeIngredients;
+	recipe_ingredients: RecipeIngredient[];
 	recipe_create_time: RecipeCreateTime;
 
 	image_url: string;
@@ -69,12 +70,33 @@ export default function RecipeDetail() {
 				}
 			} catch (error) {
 				navigate('/404');
-				console.log('데이터를 가져오지 못함', error);
+				console.log('데이터 전송 오류', error);
 			}
 		};
 
 		getRecipe();
 	}, [db, navigate]);
+
+	console.log(recipeData);
+
+	// 작성한 날짜 데이터 받아오기
+	function createTime(seconds: number | undefined): string {
+		if (typeof seconds === 'undefined') {
+			return '비어있는 값입니다.';
+		}
+		const date = new Date(seconds * 1000);
+		const year = date.getFullYear();
+		const month = String(date.getMonth() + 1).padStart(2, '0');
+		const day = String(date.getDate()).padStart(2, '0');
+
+		return `${year}-${month}-${day}`;
+	}
+
+	const times = {
+		seconds: recipeData?.recipe_create_time.seconds,
+		nanoseconds: recipeData?.recipe_create_time.nanoseconds,
+	};
+	const formatDay = createTime(times.seconds);
 
 	// 레시피 팁 데이터의 여부를 확인하고 있으면 데이터를 넣고, 없으면 문구를 넣는다.
 	const recipeTip: () => string = () => {
@@ -105,7 +127,7 @@ export default function RecipeDetail() {
 					<h3>{recipeData?.recipe_name}</h3>
 
 					<ul>
-						<li>date</li>
+						<li>{formatDay}</li>
 						<li>
 							<img src={viewIcon} alt="조회수 아이콘" />
 							{recipeData?.views}
@@ -146,47 +168,13 @@ export default function RecipeDetail() {
 							레시피 <em>Recipe</em>
 						</h4>
 
-						<div className={styled.cookingIngredientList}>
-							<ul>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-							</ul>
-							<ul>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-								<li>
-									홍가리비<span>1kg</span>
-								</li>
-							</ul>
+						<div>
+							{recipeData && (
+								<GroupedIngredientList
+									ingredients={recipeData.recipe_ingredients}
+									className={styled.cookingIngredientList}
+								/>
+							)}
 						</div>
 					</div>
 


### PR DESCRIPTION
## 기능
### 새로운 컴포넌트 생성
- 재료 리스트를 효과적으로 구현하기 위해 그룹핑 재료 리스트 컴포넌트 추가
- 재료는 각 6개씩 한 묶음으로 ul 태그에 생성됩니다.
- 재료가 6개 이상이 될 경우 새로운 ul 태그를 생성해서 추가합니다.
- 받아오는 데이터를 그룹핑 하기 위해 배열의 배열 형태로 데이터를 받아줍니다.
- 함수형 컴포넌트 타입을 선언해주고 props의 타입을 지정해줍니다.

### 레시피 상세페이지 수정 리스트
- 그룹 기능을 만들어둔 레시피 재료 리스트 컴포넌트를 불러올 수 있습니다.
- 그룹 재료 리스트 컴포넌트에 재료와 클래스 네임을 프롭스로 전달해줍니다.
- 받아오는 재료리스트의 타입을 복수형이 아닌 단수형으로 수정 후 [] 배열 형태로 수정했습니다.
- 작성한 날짜 데이터를 받아와 생성자 함수로 값을 변환
- 포맷팅한 날짜를 화면에 뿌립니다.

## 기타
- 데이터 전송 실패 시 콘솔 메세지 수정
- 불필요한 html 코드 삭제

### CSS
- 재료 리스트가 6개 미만일 경우 모든 너비를 차지 하도록 수정
