### PR TITLE
feat: 비밀번호 변경 재로그인, 로고 버튼 추가, 닉네임 변경 부분 코드 추가

### DIFF
--- a/src/pages/auth/profile/Profile.module.css
+++ b/src/pages/auth/profile/Profile.module.css
@@ -7,12 +7,21 @@
     flex-direction: column; 
 }
 
+.wrapper{
+    width: 1280px;
+}
 .logo{
     margin-bottom: 54px;
-    font-size: 28px;
+    position: relative;
 }
 .logo img{
     margin-bottom: 10px;
+}
+.logo h1{
+    font-size: 28px;
+}
+.backIcon{
+    float: left;
 }
 
 .profileBox{


### PR DESCRIPTION
- 비밀번호 변경시 알림창으로 알려주고 강제 로그아웃 후 로그인 페이지로 이동 가능
- 로고 부분에 홈으로 가는 버튼 추가
- 닉네임 변경 시 동일하게 수정되는 부분 코드 수정